### PR TITLE
CASMPET-5231: Rebuild to pick up security fixes, set up auto-rebuild

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -5,6 +5,10 @@ pipeline {
       label "metal-gcp-builder"
   }
 
+  triggers {
+      cron '@weekly'
+  }
+
   options {
       buildDiscarder(logRotator(numToKeepStr: "10"))
       timestamps()
@@ -41,7 +45,7 @@ pipeline {
       // Environment is set here because otherwise the values weren't consistent.
       environment {
         DISTROLESS_TAG = "${env.TAG}-distroless"
-        VARIANT = "cray1"
+        VARIANT = "cray2"
         VARIANT_DISTRO_TAG = "${env.TAG}-${env.VARIANT}"
         VARIANT_DISTROLESS_TAG = "${env.TAG}-${env.VARIANT}-distroless"
       }
@@ -62,7 +66,7 @@ pipeline {
       // Environment is set here because otherwise the values weren't consistent.
       environment {
         DISTROLESS_TAG = "${env.TAG}-distroless"
-        VARIANT = "cray1"
+        VARIANT = "cray2"
         VARIANT_DISTRO_TAG = "${env.TAG}-${env.VARIANT}"
         VARIANT_DISTROLESS_TAG = "${env.TAG}-${env.VARIANT}-distroless"
       }

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -18,8 +18,8 @@ COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 RUN chown -R istio-proxy /var/lib/istio
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-# CRAY: The image is the latest as of 2021-09-03
-FROM gcr.io/distroless/cc@sha256:627e2aade1375412f5e4d9f9e9ff47049feff37f0214625517a0298dc1d1adb0 as distroless
+# CRAY: Use the latest distroless base image when this is rebuilt.
+FROM gcr.io/distroless/cc:latest as distroless
 
 # TODO(https://github.com/istio/istio/issues/17656) clean up this hack
 COPY --from=default /sbin/xtables-multi /sbin/iptables* /sbin/ip6tables* /sbin/ip /sbin/


### PR DESCRIPTION
### Summary and Scope

The proxyv2 Docker file is changed to always use the latest base
distroless image rather than pinning to a specific hash.

Also, the build is now run weekly.

This is so that we pick up security fixes that are available.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Yes

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

* Resolves CASMPET-5231

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     N.  If not, Why? Doesn't seem worth it for this change.
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed with the new distroless images, made sure the right images were used, then I made sure I could make requests.
Upgraded to the new distroless images,made sure the right images were used, then I made sure I could make requests.
Deployed with the new distroful images, made sure the right images were used, then I made sure I could make requests.
Upgraded to the new distroful images, made sure the right images were used, then I made sure I could make requests.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: None
