### PR TITLE
CASMPET-5577: change the distroless image with fix from CASMPET-5231

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -22,7 +22,7 @@ RUN chown -R istio-proxy /var/lib/istio
 # It is built on the base distroless image, with iptables binary and libraries added
 # The source can be found at https://github.com/istio/distroless/tree/iptables
 # CRAY: Use the latest distroless base image when this is rebuilt.
-FROM gcr.io/istio-release/iptables:latest as distroless
+FROM gcr.io/distroless/cc:latest as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR fixes the distroless image for istio 1.9 upgrade by pulling in a previous change for CASMPET-5231. I verified that the fix addressed the issue we saw in vshasta.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
