### PR TITLE
CASMPET-6677 Add standard labels on top of istio images

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -51,14 +51,14 @@ pipeline {
       }
 
       steps {
-        sh "echo TAG=${env.TAG} DISTROLESS_TAG=${env.DISTROLESS_TAG} VARIANT_DISTRO_TAG=${env.VARIANT_DISTRO_TAG} VARIANT_DISTROLESS_TAG=${env.VARIANT_DISTROLESS_TAG}"
-
-        sh "docker tag istio/pilot:${env.TAG} istio/pilot:${VARIANT_DISTRO_TAG}"
-        sh "docker tag istio/operator:${env.TAG} istio/operator:${VARIANT_DISTRO_TAG}"
-        sh "docker tag istio/proxyv2:${env.TAG} istio/proxyv2:${VARIANT_DISTRO_TAG}"
-        sh "docker tag istio/pilot:${env.DISTROLESS_TAG} istio/pilot:${VARIANT_DISTROLESS_TAG}"
-        sh "docker tag istio/operator:${env.DISTROLESS_TAG} istio/operator:${VARIANT_DISTROLESS_TAG}"
-        sh "docker tag istio/proxyv2:${env.DISTROLESS_TAG} istio/proxyv2:${VARIANT_DISTROLESS_TAG}"
+        script {
+          sh "echo TAG=${env.TAG} DISTROLESS_TAG=${env.DISTROLESS_TAG} VARIANT_DISTRO_TAG=${env.VARIANT_DISTRO_TAG} VARIANT_DISTROLESS_TAG=${env.VARIANT_DISTROLESS_TAG}"
+          ["istio/pilot", "istio/operator", "istio/proxyv2"].each { name ->
+            // Rebuild images to add LABEL layers on top
+            sh "echo 'FROM ${name}:${env.TAG}' | docker build ${getDockerBuildArgs(name: name, version: env.TAG, mountNetRC: false)} -t '${name}:${env.VARIANT_DISTRO_TAG}' -"
+            sh "echo 'FROM ${name}:${env.DISTROLESS_TAG}' | docker build ${getDockerBuildArgs(name: name, version: env.DISTROLESS_TAG, mountNetRC: false)} -t '${name}:${env.VARIANT_DISTROLESS_TAG}' -"
+          }
+        }
       }
     }
 


### PR DESCRIPTION
# Summary

This will add standard labels to container images produced from `istio` repo. Standard labels will allo daily image rebuild job to trigger image rebuilds.

- [x] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure

# Testing
* CI/CD build succeeded: https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fistio/detail/feature%2Fimage-labels/4/pipeline/53
* Dev images produced as result of CI/CD build now have proper labels:

        $ skopeo inspect docker://artifactory.algol60.net/csm-docker/unstable/istio/proxyv2:1.11.8-20230707204931_01be98f-cray1-distroless
        ...
        {
            "Labels": {
                "org.label-schema.build-date": "2023-07-07T20:54:16Z",
                "org.label-schema.build-url": "https://jenkins.algol60.net/job/Cray-HPE/job/istio/job/feature%252Fimage-labels/",
                "org.label-schema.name": "istio/proxyv2",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.url": "http://www.cray.com/",
                "org.label-schema.vcs-ref": "01be98f0d638ca6c64df2d5c45c4c2510d80b711",
                "org.label-schema.vcs-url": "https://github.com/Cray-HPE/istio.git",
                "org.label-schema.vendor": "Cray Inc",
                "org.label-schema.version": "1.11.8-20230707204931_01be98f-distroless"
            },
        ...
        $ skopeo inspect docker://artifactory.algol60.net/csm-docker/unstable/istio/proxyv2:1.11.8-20230707204931_01be98f-cray1
        {
        ...
            "Labels": {
                "org.label-schema.build-date": "2023-07-07T20:54:15Z",
                "org.label-schema.build-url": "https://jenkins.algol60.net/job/Cray-HPE/job/istio/job/feature%252Fimage-labels/",
                "org.label-schema.name": "istio/proxyv2",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.url": "http://www.cray.com/",
                "org.label-schema.vcs-ref": "01be98f0d638ca6c64df2d5c45c4c2510d80b711",
                "org.label-schema.vcs-url": "https://github.com/Cray-HPE/istio.git",
                "org.label-schema.vendor": "Cray Inc",
                "org.label-schema.version": "1.11.8-20230707204931_01be98f"
            },
        ...


# Pull Request Attributes

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
